### PR TITLE
Support pluginHelper's genDateTimePickerDisabledStr() now using isSec…

### DIFF
--- a/fng-bootstrap-datetime.js
+++ b/fng-bootstrap-datetime.js
@@ -173,12 +173,12 @@ angular.module('ui.bootstrap.datetimepicker', ["ui.bootstrap.dateparser", "ui.bo
             // ****************************************************
             // HACK RIGHT HERE!
             // For cases where formsAngular.elemSecurityFuncBinding is set to either "one-time" or "normal", the
-            // result of the call to genDateTimePickerDisabledStr() made by the fngUiBootstrapDatetimePicker directive will
-            // include reference(s) to the function identified by formsAngular.elemSecurityFuncName (with the
-            // assumption that external code has assigned a function of that name to $rootScope).  because our
+            // result of the call to handleReadOnlyDisabled() made by the fngUiBootstrapDatetimePicker directive will
+            // include reference(s) to the function identified by formsAngular.disabledSecurityFuncName (with the
+            // assumption that external code has assigned a function of that name to $rootScope).  Because our
             // scope is isolated, this will be inaccessible unless we do the following...:
             if (formsAngular.elemSecurityFuncName) {
-              $scope[formsAngular.elemSecurityFuncName] = $scope.$root[formsAngular.elemSecurityFuncName];
+              $scope[formsAngular.disabledSecurityFuncName] = $scope.$root[formsAngular.disabledSecurityFuncName];
               $scope.isSecurelyDisabled = $scope.$parent.isSecurelyDisabled;
               $scope.isSecurelyHidden = $scope.$parent.isSecurelyHidden;
             }            

--- a/fng-bootstrap-datetime.js
+++ b/fng-bootstrap-datetime.js
@@ -173,15 +173,14 @@ angular.module('ui.bootstrap.datetimepicker', ["ui.bootstrap.dateparser", "ui.bo
             // ****************************************************
             // HACK RIGHT HERE!
             // For cases where formsAngular.elemSecurityFuncBinding is set to either "one-time" or "normal", the
-            // result of the call to handleReadOnlyDisabled() made by the fngUiBootstrapDatetimePicker directive will
-            // include reference(s) to the function identified by formsAngular.disabledSecurityFuncName (with the
-            // assumption that external code has assigned a function of that name to $rootScope).  Because our
-            // scope is isolated, this will be inaccessible unless we do the following...:
-            if (formsAngular.elemSecurityFuncName) {
-              $scope[formsAngular.disabledSecurityFuncName] = $scope.$root[formsAngular.disabledSecurityFuncName];
+            // result of the call to handleReadOnlyDisabled() made by the fngUiBootstrapDatetimePicker directive might
+            // include reference(s) to two functions which our ancestor form scope should have been decorated with -
+            // isSecurelyDisabled and requiresDisabledChildren.  Because our scope is isolated, these will be
+            // inaccessible to us unless we do the following...:
+            if (formsAngular.disabledSecurityFuncName) {
               $scope.isSecurelyDisabled = $scope.$parent.isSecurelyDisabled;
-              $scope.isSecurelyHidden = $scope.$parent.isSecurelyHidden;
-            }            
+              $scope.requiresDisabledChildren = $scope.$parent.requiresDisabledChildren;
+            }   
             // as this is only going to work for disabled state arising from fng security, and not the case
             // where an fng field has a string-valued readonly attribute that refers to a function on the parent 
             // scope, it's only a partial solution.  the general solution would presumably be to replace our isolated

--- a/fng-bootstrap-datetime.js
+++ b/fng-bootstrap-datetime.js
@@ -173,12 +173,14 @@ angular.module('ui.bootstrap.datetimepicker', ["ui.bootstrap.dateparser", "ui.bo
             // ****************************************************
             // HACK RIGHT HERE!
             // For cases where formsAngular.elemSecurityFuncBinding is set to either "one-time" or "normal", the
-            // result of the call to handleReadOnlyDisabled() made by the fngUiBootstrapDatetimePicker directive will
+            // result of the call to genDateTimePickerDisabledStr() made by the fngUiBootstrapDatetimePicker directive will
             // include reference(s) to the function identified by formsAngular.elemSecurityFuncName (with the
             // assumption that external code has assigned a function of that name to $rootScope).  because our
             // scope is isolated, this will be inaccessible unless we do the following...:
             if (formsAngular.elemSecurityFuncName) {
               $scope[formsAngular.elemSecurityFuncName] = $scope.$root[formsAngular.elemSecurityFuncName];
+              $scope.isSecurelyDisabled = $scope.$parent.isSecurelyDisabled;
+              $scope.isSecurelyHidden = $scope.$parent.isSecurelyHidden;
             }            
             // as this is only going to work for disabled state arising from fng security, and not the case
             // where an fng field has a string-valued readonly attribute that refers to a function on the parent 


### PR DESCRIPTION
…urelyDisabled and isSecurelyHidden on the form scope rather than the elemSecurityFuncName on $rootScope